### PR TITLE
Fix model loading on multi-GPU environment

### DIFF
--- a/tools/extract_features.py
+++ b/tools/extract_features.py
@@ -150,7 +150,7 @@ def ExtractFeatures(args):
                 model,
                 args.load_model_path,
                 use_gpu=True,
-                root_gpu_id=gpus[0]
+                gpu_ids=gpus
             )
         else:
             model_loader.LoadModelFromPickleFile(

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -163,7 +163,7 @@ def Test(args):
                 test_model,
                 args.load_model_path,
                 use_gpu=True,
-                root_gpu_id=gpus[0]
+                gpu_ids=gpus
             )
             data_parallel_model.FinalizeAfterCheckpoint(test_model)
         else:

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -348,7 +348,7 @@ def Train(args):
             model_loader.LoadModelFromPickleFile(
                 train_model,
                 args.pretrained_model,
-                root_gpu_id=gpus[0]
+                gpu_ids=gpus
             )
 
         data_parallel_model.FinalizeAfterCheckpoint(


### PR DESCRIPTION
When running `extract-feature.py --gpus=0,1,2,3,4 ...` on multi-GPU environment,
recognition result by GPU-0 is fair, but results by GPU-1,2,3,4 are not fair.
For instance, all softmax values are 0.0025.

I think that the script loads model to the first GPU only.